### PR TITLE
Change paths to work with Nix package system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ else
 endif
 endif
 
-TIME = /usr/bin/time
+TIME := $(shell which time)
 TIMEDIR = $(PWD)/time
 TIMEO = $(shell ($(TIME) -o /dev/null ls >/dev/null && echo "yes" ))
 ifeq ($(TIMEO),yes)

--- a/alicebld/wrapper.sh
+++ b/alicebld/wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 source config.sh
 source log.sh

--- a/bootstrap/platform.sh
+++ b/bootstrap/platform.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if [ -x /bin/uname ]; then UNAME=/bin/uname
 elif [ -x /usr/bin/uname ]; then UNAME=/usr/bin/uname

--- a/doc/samples/snake/run.sh
+++ b/doc/samples/snake/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if [ `uname | head -c 6 | tr [A-Z] [a-z]` = "cygwin" ]; then
   export ALICE_JIT_MODE=0 #little workaround

--- a/lib/gtk/seam/myinstall
+++ b/lib/gtk/seam/myinstall
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This little shell script tests whether install has the -C option,
 # and uses it if it exists. 

--- a/misc/logo/alice-to-bmp.sh
+++ b/misc/logo/alice-to-bmp.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 gs="gs -q -dBATCH -dNOPAUSE -sDEVICE=bmp16m -r300"
 

--- a/misc/release/changelog.sh
+++ b/misc/release/changelog.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # This script prepends a new changelog entry to all changelog files
 # found in PATHS.

--- a/misc/release/version.sh
+++ b/misc/release/version.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # This script modifies the version number in all files listed in FILES
 # to the version number specified by alicetool.

--- a/test/icfp2000/submit.sh
+++ b/test/icfp2000/submit.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 icfpaddress=icfp-sub@cs.cornell.edu
 icfpsubject="ICFPsubmission"
 

--- a/test/suite/run.sh
+++ b/test/suite/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if [ `uname | head -c 6 | tr [A-Z] [a-z]` = "cygwin" ]; then
   ARG=PLATFORM_WINDOWS

--- a/vm-seam/bin/alice
+++ b/vm-seam/bin/alice
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 exec $(dirname $0)/alicerun x-alice:/compiler/ToplevelMain "$@"

--- a/vm-seam/bin/aliceremote
+++ b/vm-seam/bin/aliceremote
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Author:
 #   Andreas Rossberg <rossberg@ps.uni-sb.de>

--- a/vm-seam/bin/alicerun.in
+++ b/vm-seam/bin/alicerun.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Author:
 #   Marco Kuhlmann <kuhlmann@ps.uni-sb.de>


### PR DESCRIPTION
Nix has a non-standard file system layout. These changes stop
looking for bash in /bin and similar changes. It uses /usr/bin/env
to find locations of shells and other similar tricks.
